### PR TITLE
Build and run pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "clap"
-version = "4.5.15"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
 ]
@@ -91,12 +91,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
-name = "h"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f3a816cd14d617d725fb3b45e5572ceab36ddb0de07761ec4cabe77aed3c95"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,15 +102,14 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "clap",
- "h",
  "termios",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 [dependencies]
 byteorder = "1.5.0"
 clap = { version = "4.5.15", features = ["cargo"] }
-h = "0.1.0"
 termios = "0.3.3"

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,16 @@
+# runs the lc-3 in debug mode with the 2048 obj file
+default: run-2048
+
+# build the lc-3 in release mode and install the binary
+build:
+    cargo build --release
+    cargo install --path .
+
+test:
+    cargo test
+
+run-2048:
+    cargo run -- -i ./images/2048.obj
+
+run-rogue:
+    cargo run -- -i ./images/rogue.obj

--- a/README.md
+++ b/README.md
@@ -3,24 +3,38 @@ An LC-3 virtual machine written in Rust, based on [Write your Own Virtual Machin
 
 ## Usage
 
-1. Clone the repository.
+1. `just build` to build and install the binary, or manually use `cargo`.
 
 2. Run:
 
+    - For help:
+
+    ```sh
+    lc3-vm -h
+    ```
+
+    - With an object file:
+
+    ```sh
+    lc3-vm -i <path-to-obj>
+    ```
+
+## Justfile
+
+Build and install binary:
+
 ```sh
-cargo run <image-file>
+just build
 ```
 
-Two example images are provided, to run:
+Alternatively, you can directly run the "2048" and "rogue" examples with:
 
 ```sh
-cargo run images/rogue.obj
+just run-2048
 ```
 
-and
-
 ```sh
-cargo run images/2048.obj
+just run-rogue
 ```
 
 ## TODO


### PR DESCRIPTION
Improved the building and running experience. Introduced a `Justfile` for quickly building and installing the VM. It's now possible to run the vm directly with the binary name, after build and install.

Added documentation for this.